### PR TITLE
use actual hex not decimal for FF = ctrl-L

### DIFF
--- a/lib/Pegex/Grammar/Atoms.pm
+++ b/lib/Pegex/Grammar/Atoms.pm
@@ -98,7 +98,7 @@ my $atoms = {
 
     # Special rules for named control chars
     BS      => '\x08',    # Backspace
-    FF      => '\x12',    # Formfeed
+    FF      => '\x0C',    # Formfeed
 };
 
 sub atoms { return $atoms }


### PR DESCRIPTION
ctrl-L = 12th char = hex \0C not \12