### PR TITLE
Update list of required packages

### DIFF
--- a/Meta
+++ b/Meta
@@ -24,10 +24,16 @@ devel:
 requires:
   perl: 5.8.1
   Scalar::Util: 0
+  Carp: 0
+  File::ShareDir::Install: 0
+  JSON::XS: 0
+  YAML::XS: 0
+  XXX: 0
 
 test:
   requires:
     YAML::XS: 0.74
+    Test::Pod: 0
 
 =zild:
   include_testml: 1


### PR DESCRIPTION
Which should fix the current [prereq_matches_use CPANTS issues](https://cpants.cpanauthors.org/dist/Pegex).  Keeping this list up to date also helps other tools such as CPAN testers and MetaCPAN to find information about dependencies more easily.