### PR TITLE
Replace two-arg open with three-arg open

### DIFF
--- a/eg/calculator/lib/Runner.pm
+++ b/eg/calculator/lib/Runner.pm
@@ -22,7 +22,7 @@ sub run {
 sub run_file {
     my ($self) = @_;
     my $file = shift(@{$self->args});
-    open IN, $file or die "Can't open '$file' for input";
+    open IN, "<", $file or die "Can't open '$file' for input";
     while (<IN>) {
         next if /^(?:#|$)/;
         chomp;

--- a/lib/Pegex/Grammar.pm
+++ b/lib/Pegex/Grammar.pm
@@ -18,7 +18,7 @@ sub make_text {
     my ($self) = @_;
     my $filename = $self->file
         or return '';
-    open TEXT, $filename
+    open TEXT, "<", $filename
         or die "Can't open '$filename' for input\n:$!";
     return do {local $/; <TEXT>}
 }
@@ -73,7 +73,7 @@ sub import {
 sub compile_into_module {
     my ($package) = @_;
     my $grammar_file = $package->file;
-    open GRAMMAR, $grammar_file
+    open GRAMMAR, "<", $grammar_file
         or die "Can't open $grammar_file for input";
     my $grammar_text = do {local $/; <GRAMMAR>};
     close GRAMMAR;
@@ -94,7 +94,7 @@ sub compile_into_module {
         require Pegex::Compiler;
         $perl = Pegex::Compiler->new->compile($grammar_text, @rules)->to_perl;
     }
-    open IN, $file or die $!;
+    open IN, "<", $file or die $!;
     my $module_text = do {local $/; <IN>};
     require Pegex;
     my $msg = "   # Generated/Inlined by Pegex::Grammar ($Pegex::VERSION)";

--- a/lib/Pegex/Input.pm
+++ b/lib/Pegex/Input.pm
@@ -36,7 +36,7 @@ sub open {
         $self->{_buffer} = \ do { local $/; <$handle> };
     }
     elsif (my $path = $self->{file}) {
-        open my $handle, $path
+        open my $handle, "<", $path
             or die "Pegex::Input can't open $path for input:\n$!";
         $self->{_buffer} = \ do { local $/; <$handle> };
     }


### PR DESCRIPTION
The three-argument version of the `open` function is considered better
practice than the older two-argument `open`.

This pull request is intended to be helpful.  If you have any questions or comments, please don't hesitate to contact me and I'll update the PR as necessary and resubmit.