### PR TITLE
Add initial AppVeyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,14 @@
+cache:
+    - C:\Strawberry -> .appveyor_clear_cache.txt
+
+shallow_clone: true
+
+install:
+  - if not exist "C:\Strawberry" cinst strawberryperl
+  - set
+    PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  - cpanm --quiet --notest YAML::XS TestML
+
+build_script:
+  - prove -lv test


### PR DESCRIPTION
[AppVeyor](https://ci.appveyor.com) is a continuous integration service for open source projects to test their code on Windows systems.

This PR is submitted in the hope that it is helpful; if you'd like it changed in any way, please just let me know.  My guess is that you would rather merge this kind of functionality into [Zilla::Dist], however this gives an example file which builds successfully for Pegex.