### PR TITLE
Add strict and warnings pragmas to test scripts

### DIFF
--- a/test/api.t
+++ b/test/api.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 
 use Pegex::Parser;

--- a/test/export-api.t
+++ b/test/export-api.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 # BEGIN { $Pegex::Parser::Debug = 1 }
 use Test::More tests => 8;
 

--- a/test/flatten.t
+++ b/test/flatten.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 1;
 use Pegex;
 

--- a/test/function-rule.t
+++ b/test/function-rule.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 use Pegex::Parser;
 

--- a/test/grammar-api.t
+++ b/test/grammar-api.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 1;
 
 package MyGrammar1;

--- a/test/parse.t
+++ b/test/parse.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 # $Pegex::Parser::Debug = 1;
 
 my $t; use lib ($t = -e 't' ? 't' : 'test');
@@ -6,7 +9,7 @@ use Test::More tests => 1;
 use Pegex;
 use Pegex::Input;
 
-$grammar_file = "$t/mice.pgx";
+my $grammar_file = "$t/mice.pgx";
 
 eval { pegex( Pegex::Input->new(file => $grammar_file) )->parse("3 blind mice\n") }; $@
 ? fail $@

--- a/test/repeat.t
+++ b/test/repeat.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 
 use Pegex;

--- a/test/safe.t
+++ b/test/safe.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 
 # 2015-02-03 Safe.pm fails to load on Travis + 5.14

--- a/test/sample.t
+++ b/test/sample.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 
 eval "use YAML::XS; 1" or


### PR DESCRIPTION
It seems that the library code embeds strict and warnings within `Pegex::Base` and hence the pragmas are active but not explicitly in the source files.  Unfortunately `Perl::Critic` can't find them, nevertheless, the pragmas should probably be in the test scripts, which this PR adds.  As with all my PRs, this is intended to be helpful and if you want it changed in some way, please let me know and I'll update the PR and resubmit.