### PR TITLE
Fix stale URLs

### DIFF
--- a/doc/Pegex/Miscellany.swim
+++ b/doc/Pegex/Miscellany.swim
@@ -105,7 +105,7 @@ https://github.com/ingydotnet/testml-pgx/blob/master/testml.pgx.json
 
 Pegex::Compiler further compiles this into a Perl 5 only grammar tree, which
 becomes this module:
-https://github.com/ingydotnet/testml-pm/blob/master/lib/TestML/Grammar.pm
+https://github.com/ingydotnet/testml-pm/blob/master/lib/TestML/Compiler/Pegex/Grammar.pm
 
 TestML::Parser::Grammar is a subclass of Pegex::Grammar. It can be used to
 parse TestML files. TestML::Parser calls the [parse()] method of the grammar

--- a/doc/Pegex/Resources.swim
+++ b/doc/Pegex/Resources.swim
@@ -44,6 +44,6 @@ parsers:
 
 * "The Pegex Perl Module"[https://github.com/ingydotnet/pegex-pm]
 * "The TestML Perl Module"[https://github.com/ingydotnet/testml-pm]
-* "A JSON Decoder Perl Module"[https://github.com/ingydotnet/pegex-json-pgx]
+* "Pegex JSON Parser for Perl"[https://github.com/ingydotnet/pegex-json-pm]
 * "A JSONY Decoder Perl Module"[https://github.com/ingydotnet/json-pgx]
 * "A CronTab Parser Perl Module"[https://github.com/ingydotnet/pegex-crontab-pm]

--- a/doc/Pegex/Tutorial.swim
+++ b/doc/Pegex/Tutorial.swim
@@ -12,8 +12,8 @@ This document is just an index to the current tutorials.
 
 - [Pegex::Tutorial::Calculator]
 
-  Pegex comes with an `examples/` directory. One example is
-  [Pegex/examples/calculator.pl]. It's a simple precedence parser (and
+  Pegex comes with an `eg/` directory. One example is
+  [Pegex/eg/calculator/calculator1.pl]. It's a simple precedence parser (and
   evaluator) for arithmetic expressions like this one:
 
     1 * (2 + 3) / (4 ^ 5 ^ 6 - -7)

--- a/doc/Pegex/Tutorial/Calculator.swim
+++ b/doc/Pegex/Tutorial/Calculator.swim
@@ -233,11 +233,6 @@ changed the runner code to look like this:
       print $@ || "$expr = $result\n";
   }
 
-As you can see I also moved the evaluator code into a
-separate/reusable module: [example/lib/RPN.pm]. This is another 30
-lines of Perl. Please take a look at it.
-[https://github.com/ingydotnet/pegex-pm/blob/master/eg/lib/RPN.pm]
-
 So overall, this second solution was a bit more code, but also feels
 more solid on several levels.
 

--- a/doc/Pegex/Tutorial/Calculator.swim
+++ b/doc/Pegex/Tutorial/Calculator.swim
@@ -15,8 +15,8 @@ This tutorial is the Pegex version of that. Pegex actually comes with an
 examples directory that contains two arithmetic expression parser/evaluator
 caclulator programs:
 
-* https://github.com/ingydotnet/pegex-pm/blob/master/eg/calculator1.pl
-* https://github.com/ingydotnet/pegex-pm/blob/master/eg/calculator2.pl
+* https://github.com/ingydotnet/pegex-pm/blob/master/eg/calculator/calculator1.pl
+* https://github.com/ingydotnet/pegex-pm/blob/master/eg/calculator/calculator2.pl
 
 They both do the same thing but using different parsing approaches. We'll
 cover both of them in detail. I hope you'll find that Pegex handles operator
@@ -211,7 +211,7 @@ a separate base class called [example/lib/Precedence.pm].
 This is an implementation of Edsger Dijkstra's famous Shunting-yard
 Algorithm from 1961! It's only 20 lines of Perl. I won't include it
 inline here, but have a look at it for yourself.
-[https://github.com/ingydotnet/pegex-pm/blob/master/eg/lib/Precedence.pm]
+[https://github.com/ingydotnet/pegex-pm/blob/master/eg/calculator/lib/Precedence.pm]
 
 The Shunting-yard algorithm simply takes a list of expression tokens
 and transforms them into an RPN stack. It uses information from a

--- a/ext/pegex-pgx/note/CafePlan.md
+++ b/ext/pegex-pgx/note/CafePlan.md
@@ -30,7 +30,7 @@ in, needs to be converted.
 
 See:
 
-* https://github.com/michaelficarra/CoffeeScriptRedux/blob/master/src/grammar.pegjs
+* https://github.com/michaelficarra/CoffeeScriptRedux/blob/master/src/grammar.pegcoffee
 * https://github.com/ingydotnet/pegex-pm
 * https://github.com/ingydotnet/testml-pm
 

--- a/ext/pegex-pgx/note/Links
+++ b/ext/pegex-pgx/note/Links
@@ -13,7 +13,7 @@ Web Links
 
 
 # Grammars / Definitions (some PEG)
-- http://flash-gordon.me.uk/ansi.c.txt — C grammar
+- http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf — C grammar
 - http://ssw.jku.at/Coco/ — ATG grammars
 - www.yaml.org/spec/1.2/ — YAML grammar
 - http://www.w3.org/TR/xml11/ — XML grammar
@@ -28,7 +28,7 @@ Web Links
 
 
 # PEG Frameworks / Implementations
-- http://treetop.rubyforge.org/ — PEG parser in Ruby
+- https://github.com/nathansobo/treetop/ — PEG parser in Ruby
 - http://kschiess.github.io/parslet/ — PEG parser in Ruby
 - https://github.com/PhilippeSigaud/Pegged/wiki/_pages — PEG Parser in D
 - http://piumarta.com/software/peg/ — peg/leg PEG Parser in C


### PR DESCRIPTION
Some of the URLs mentioned in the docs are outdated.  This PR updates them to point to the new locations, or uses new URLs where necessary.