### PR TITLE
Fix minor typos in docs

### DIFF
--- a/ReadMe.pod
+++ b/ReadMe.pod
@@ -71,7 +71,7 @@ I<just>modern languages that have a normal regular expression engine
 available.
 
 Pegex gets it name by combining Parsing Expression Grammars (PEG), with
-Regular Expessions (Regex). That's actually what Pegex does.
+Regular Expressions (Regex). That's actually what Pegex does.
 
 PEG is the cool new way to elegantly specify recursive descent grammars. The
 Perl 6 language is defined in terms of a self modifying PEG language called

--- a/doc/Pegex.swim
+++ b/doc/Pegex.swim
@@ -56,7 +56,7 @@ language *Perl 6* is based on. Pegex brings this beauty to the other
 /just/modern languages that have a normal regular expression engine available.
 
 Pegex gets it name by combining Parsing Expression Grammars (PEG), with
-Regular Expessions (Regex). That's actually what Pegex does.
+Regular Expressions (Regex). That's actually what Pegex does.
 
 PEG is the cool new way to elegantly specify recursive descent grammars. The
 Perl 6 language is defined in terms of a self modifying PEG language called

--- a/doc/Pegex/API.swim
+++ b/doc/Pegex/API.swim
@@ -51,7 +51,7 @@ briefly:
   concept you will encounter the least, but it is covered here for
   completeness.
 
-All of these object classes can be subclassed to acheive various results.
+All of these object classes can be subclassed to achieve various results.
 Normally, you will write your own Pegex grammar and a Pegex receiver to
 achieve a task.
 

--- a/doc/Pegex/Compiler.swim
+++ b/doc/Pegex/Compiler.swim
@@ -61,7 +61,7 @@ The following public methods are available:
   Pegex::Parser.
 
   NOTE: While the parse phase of a compile is always the same for various
-  programming langugaes, the combinate phase takes into consideration and
+  programming languages, the combinate phase takes into consideration and
   special needs of the target language. Pegex::Compiler only combinates for
   Perl, although this is often sufficient in similar languages like Ruby or
   Python (PCRE based regexes). Languages like Java probably need to use their

--- a/doc/Pegex/Input.swim
+++ b/doc/Pegex/Input.swim
@@ -13,7 +13,7 @@ Pegex Parser Input Abstraction
 
 Pegex::Parser parses input. The input can be a string, a string reference, a
 file path, or an open file handle. Pegex::Input is an abstraction over any type
-of input. It provides a uniform inteface to the parser.
+of input. It provides a uniform interface to the parser.
 
 = Usage
 

--- a/doc/Pegex/Overview.swim
+++ b/doc/Pegex/Overview.swim
@@ -22,7 +22,7 @@ and possibly doing something with what is found.
 Usually a parser gets its instructions of what means what from something
 called a grammar. A grammar is a set of rules that defines how the input must
 be structured. In many parsing methodologies, input is preprocessed (possibly
-into tokesn) before the parser/grammar get to look at it. Although this is
+into tokens) before the parser/grammar get to look at it. Although this is
 a common method, it is not the only approach.
 
 = How Pegex Works

--- a/doc/Pegex/Regex.swim
+++ b/doc/Pegex/Regex.swim
@@ -26,7 +26,7 @@ You put a grammar into a `qr{...}x` and apply it the input string you want to
 parse. If the parse is successful, you get a data structure of the content in
 `%/`.
 
-IMHO, building a recursive decscent parser entirely inside of a regular
+IMHO, building a recursive descent parser entirely inside of a regular
 expression, is not the clearest way to code. But, of course, TMTOWTDI. :)
 
 = Note

--- a/doc/Pegex/Syntax.swim
+++ b/doc/Pegex/Syntax.swim
@@ -90,7 +90,7 @@ error message.
 `LSQUARE`, `RSQUARE` and `COMMA` are also rule references. Rules may be
 referred to inside of regexes, as long as they refer to regexes themselves. In
 this way big regexes can be assembled from smaller ones, thus leading to reuse
-and readability. Finally, the '*' after `node` is called a "quntifier". More
+and readability. Finally, the '*' after `node` is called a "quantifier". More
 about those later.
 
 == Rule References
@@ -134,7 +134,7 @@ Note that you must use angle brackets if you are using a numbered modifier:
 There is a special set of predefined "[Atoms|Pegex::Grammar::Atoms]" that
 refer to regular expression fragments. Atoms exist for every punctuation
 character and for characters commonly found in regular expressions. Atoms
-enchance readability in grammar texts, and allow special characters (like
+enhance readability in grammar texts, and allow special characters (like
 slash or hash) to be used as Pegex syntax.
 
 For example, a regex to match a comment might be '#' followed by anything,

--- a/doc/Pegex/Tutorial/Calculator.swim
+++ b/doc/Pegex/Tutorial/Calculator.swim
@@ -13,7 +13,7 @@ expressions.
 
 This tutorial is the Pegex version of that. Pegex actually comes with an
 examples directory that contains two arithmetic expression parser/evaluator
-caclulator programs:
+calculator programs:
 
 * https://github.com/ingydotnet/pegex-pm/blob/master/eg/calculator1.pl
 * https://github.com/ingydotnet/pegex-pm/blob/master/eg/calculator2.pl

--- a/doc/Pegex/Tutorial/JSON.swim
+++ b/doc/Pegex/Tutorial/JSON.swim
@@ -159,7 +159,7 @@ Pegex. This is the same as Perl's 'x' regex flag.
 
 Finally the '-' is Pegex's 'possible whitespace' indicator, and usually
 expands to `\s*`. It actually expands to `ws1`, which expands to `ws*`, which
-expands to `WS*`, which exapands to `\s*` (unless you override any of those
+expands to `WS*`, which expands to `\s*` (unless you override any of those
 rules).
 
 Getting back to JSON...
@@ -213,7 +213,7 @@ Let's take a look at that rule after Pegex compilation:
     - .rgx: \s*\}\s*
 
 The rule for 'map' says that the text must match 3 thing: a regex (opening
-curly brace), zero or more occurences of a rule called 'pair' separated by a
+curly brace), zero or more occurrences of a rule called 'pair' separated by a
 regex (comma), and finally another regex (closing curly).
 
 One thing that we have silently covered is the AND operator. That's because
@@ -275,7 +275,7 @@ Next we have the definition for a JSON string:
                       [
                           DOUBLE      # Double Quote
                           BACK        # Back Slash
-                          SLASH       # Foreward Slash
+                          SLASH       # Forward Slash
                           b           # Back Space
                           f           # Form Feed
                           n           # New Line
@@ -299,7 +299,7 @@ which Pegex compiles to this (simple and obvious;) regex:
 Let's see what's new here...
 
 First off, we have lots of whitespace and comments. This should make it pretty
-easy to at least get the overall picture of what is being accomlished.
+easy to at least get the overall picture of what is being accomplished.
 
 Understanding how the text between a pair of '/' characters gets transformed
 into a real regular expression, is the key to really understanding Pegex.
@@ -373,7 +373,7 @@ matching text was (even though in this case it has to be exactly the string
 
 = Pegex::JSON::Grammar - The Pegex Grammar Class
 
-The Pegex JSON grammar that we just looked at in excrucuating detail gets
+The Pegex JSON grammar that we just looked at in excruciating detail gets
 compiled into a Perl data structure and then embedded into a grammar class. A
 [Pegex::Parser] object (the thing that does the parsing) requires a grammar
 object (what to look for) and a receiver object (what to do when you find it).
@@ -383,7 +383,7 @@ this grammar: https://github.com/ingydotnet/pegex-pgx/blob/master/pegex.pgx
 is used by Pegex to parse our json.pgx grammar (and yes, it can parse
 pegex.pgx too).
 
-It is conceivable that everytime we wanted to parse JSON, we could parse the
+It is conceivable that every time we wanted to parse JSON, we could parse the
 json.pgx grammar first, but that would be a waste of time. So we cache the big
 grammar tree as a pure Perl data structure inside [Pegex::JSON::Grammar].
 


### PR DESCRIPTION
Found some typos by running `aspell` over the documentation.  Hope these fixes help!