### PR TITLE
Any #!testml will do, to also get testml-p5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
     -e "my $c = ff($f);"
     -e "if ($c =~ /\Atestml/) { $c = ff(qq{test/$c}) }"
     -e "$f =~ s#\Atest#t#;"
-    -e "if ($c =~ /\A#!.*testml$/m) { (my $cf = $f) =~ s#(.*)\.t$#inc/$1.tml.json#; tf($cf, TestML::Compiler->new->compile($c)); $c = qq{#!inc\\bin\\testml-cpan\r\n}; }"
+    -e "if ($c =~ /\A#!.*testml/m) { (my $cf = $f) =~ s#(.*)\.t$#inc/$1.tml.json#; tf($cf, TestML::Compiler->new->compile($c)); $c = qq{#!inc\\bin\\testml-cpan\r\n}; }"
     -e "tf($f, $c);"
   -e "}"
   -e "sub ff { local $/; open my $fh, shift; <$fh> }"


### PR DESCRIPTION
The RE before was slightly too conservative, and didn't spot `testml-p5`. It does now, and passes.